### PR TITLE
src: use id to ensure mutex is locked by us

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <version>8</version>
     </parent>
 
     <groupId>com.github.ampedandwired</groupId>
     <artifactId>bamboo-mutex-plugin</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.14-SNAPSHOT</version>
     <organization>
         <name>ampedandwired</name>
         <url>https://github.com/ampedandwired</url>


### PR DESCRIPTION
use the id of the plan to lock the mutex, to ensure the mutex is only released when the plan is stopped

This is for when you rerun an plan, and than stop before running the prechain action